### PR TITLE
+Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+INSTALLDIR=$(HOME)/bin
+PROG = yalci
+
+# Prerequest:
+# apt-get install   cargo make cmake zlib1g-dev libssl-dev
+
+all:
+	cargo build --release
+
+clean:
+	cargo clean
+	rm -f Cargo.lock
+
+install:
+	make all
+	@echo This software will be installed to $(INSTALLDIR)
+	if [ ! -e $(INSTALLDIR) ]; then mkdir $(INSTALLDIR); fi
+	cp -p target/release/$(PROG) $(INSTALLDIR)
+	strip $(INSTALLDIR)/$(PROG)
+
+uninstall:
+	rm -f $(INSTALLDIR)/$(PROG)


### PR DESCRIPTION
The command 'cargo' is new for a "classical" unix sysop. The classical sysop can use better "make" and "make install".